### PR TITLE
Remove PHPUnit 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^8.0"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates Composer to only use PHPUnit 8 by default. PHPUnit 8 only supports PHP 7.2 and later.

> [PHPUnit 7](https://phpunit.de/getting-started/phpunit-7.html) is only supported until February 7, 2020. Also note that PHP 7.1 is no longer actively supported.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
