### PR TITLE
Add GitHub Actions caching and dependency versions in the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,9 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3]
+        dependency-version: [prefer-lowest, prefer-stable]
 
-    name: CI - PHP ${{ matrix.php }}
+    name: CI - PHP ${{ matrix.php }} (${{ matrix.dependency-version }})
 
     steps:
 
@@ -33,7 +34,7 @@ jobs:
     - name: Install Composer dependencies
       run: |
         composer global require hirak/prestissimo
-        composer update --no-interaction --prefer-dist --no-suggest
+        composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-suggest
 
     - name: PHPUnit Testing
       run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,22 +4,36 @@ on: ['push', 'pull_request']
 
 jobs:
   ci:
-    name: CI
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [7.3]
+
+    name: CI - PHP ${{ matrix.php }}
+
     steps:
-    
+
     - name: Checkout
       uses: actions/checkout@v1
+
+    - name: Cache dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.composer/cache/files
+        key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
     - name: Setup PHP
       uses: shivammathur/setup-php@master
       with:
-        php-version: '7.3'
+        php-version: ${{ matrix.php }}
+        # extension-csv: mbstring, zip
 
     - name: Install Composer dependencies
       run: |
         composer global require hirak/prestissimo
-        composer update --no-interaction --prefer-dist
+        composer update --no-interaction --prefer-dist --no-suggest
 
     - name: PHPUnit Testing
       run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds caching to GitHub Actions' Composer dependencies, and also adds a matrix to allow multiple PHP versions and `--prefer-stable` / `--prefer-lowest` in Composer.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
