### PR TITLE
Update packages to use PHP 7.4 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3]
+        php: [7.4]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: CI - PHP ${{ matrix.php }} (${{ matrix.dependency-version }})
@@ -29,7 +29,7 @@ jobs:
       uses: shivammathur/setup-php@master
       with:
         php-version: ${{ matrix.php }}
-        # extension-csv: mbstring, zip
+        extensions: mbstring, zip
 
     - name: Install Composer dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@master
+      uses: shivammathur/setup-php@v1
       with:
         php-version: ${{ matrix.php }}
         extensions: mbstring, zip

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": ":package_description",
     "license": "MIT",
     "require": {
-        "php": "^7.2"
+        "php": "^7.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This updates the default PHP version to 7.4, and fixes the deprecated `extensions-csv` key usage in the workflow configuration. This also updates to use the `v1` tag of the **Setup PHP** action, rather than `master`.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
